### PR TITLE
Fixing hint order=-1 issue

### DIFF
--- a/msadmin/static/js/qa/hints.js
+++ b/msadmin/static/js/qa/hints.js
@@ -223,7 +223,7 @@ function saveHint (isExit) {
     var data = new FormData(form); // put all the form fields into data
     var probId = theProblem.id;
     // get the row # of this hint
-    var rown = getHintRowNumber(theHint.id);
+    var rown = theHint.order;
     data.append('order',rown);
     setWaitCursor(true); // change cursor to hourglass while waiting for save.
     var url_mask = SAVE_HINT_URL.replace(/12345/, probId.toString());


### PR DESCRIPTION
Newly created hints always have order=-1 on creation. The correct ordering happens only when the hints are rearranged. This change populates the order field's value and ensures that the latest hint is saved with numbers increasing from `0` to `num_hints - 1`

Closes #43 